### PR TITLE
feat: [BE1] implement GET /orders with pagination, filtering and sorting

### DIFF
--- a/backend/app/routers/taxes.py
+++ b/backend/app/routers/taxes.py
@@ -1,37 +1,44 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import desc, asc
+from datetime import datetime
+from typing import Optional
+
+from app.db.database import get_db
+from app.db.models.models import Order
+from app.schemas.order import OrdersListResponse
 from app.services.import_service import ImportService
 from app.services.tax_service import TaxCalculatorService, get_tax_service
 
 router = APIRouter(prefix="/api/taxes", tags=["Taxes"])
 
+
 @router.post("/update-dataset")
 async def update_tax_dataset(
-    tax_service: TaxCalculatorService = Depends(get_tax_service) # <-- Внедряем сервис
+    tax_service: TaxCalculatorService = Depends(get_tax_service) 
 ):
     """
     Принудительно скачивает свежую версию датасета и обновляет кэш.
     """
     import_service = ImportService()
     
-    # 1. Скачиваем новый файл
     success = await import_service.download_dataset()
     
     if not success:
         raise HTTPException(status_code=500, detail="Ошибка при скачивании датасета с сервера NY.")
     
-    # 2. Обновляем данные в оперативной памяти!
     tax_service.reload_data()
     
     return {
         "status": "success", 
         "message": "Налоговый датасет успешно обновлен и загружен в память.",
-        "records_loaded": len(tax_service.tax_data) # Приятный бонус: показываем, сколько строк загрузили
+        "records_loaded": len(tax_service.tax_data) 
     }
 @router.get("/calculate")
 async def calculate_tax(
     lat: float, 
     lon: float,
-    tax_service: TaxCalculatorService = Depends(get_tax_service) # Тот же самый экземпляр!
+    tax_service: TaxCalculatorService = Depends(get_tax_service) 
 ):
     """
     Получает налоговую ставку по координатам.
@@ -40,5 +47,36 @@ async def calculate_tax(
         data = await tax_service.get_raw_tax_data(lat, lon)
         return {"status": "success", "data": data}
     except Exception as e:
-        # Здесь мы ловим нашу кастомную ошибку OutsideNYSException (или другие)
         raise HTTPException(status_code=400, detail=str(e))
+    
+@router.get("/orders", response_model=OrdersListResponse)
+def get_orders(
+    db: Session = Depends(get_db),
+    limit: int = Query(10, ge=1, le=100), 
+    offset: int = Query(0, ge=0),         
+    start_date: Optional[datetime] = None, 
+    end_date: Optional[datetime] = None,   
+    sort_by: str = Query("timestamp", regex="^(timestamp|subtotal|tax_amount|total_amount)$"),
+    order: str = Query("desc", regex="^(asc|desc)$") 
+):
+    query = db.query(Order)
+
+    if start_date:
+        query = query.filter(Order.timestamp >= start_date)
+    if end_date:
+        query = query.filter(Order.timestamp <= end_date)
+
+    total_count = query.count()
+
+    sort_attr = getattr(Order, sort_by)
+    if order == "desc":
+        query = query.order_by(desc(sort_attr))
+    else:
+        query = query.order_by(asc(sort_attr))
+
+    orders = query.offset(offset).limit(limit).all()
+
+    return {
+        "total_count": total_count,
+        "items": orders
+    }

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -7,6 +7,7 @@ class OrderBase(BaseModel):
     longitude: float
     subtotal: float
 
+
 class OrderCreate(OrderBase):
     pass
 
@@ -21,3 +22,7 @@ class OrderResponse(OrderBase):
 
     class Config:
         from_attributes = True
+        
+class OrdersListResponse(BaseModel):
+    total_count: int
+    items: List[OrderResponse]


### PR DESCRIPTION
---
## **Опис (Description):**

Цей PR реалізує функціонал читання даних із бази даних для відображення списку замовлень у фронтенд-адмінці. Відповідно до вимог завдання **Issue 2**, API підтримує ефективну обробку великих обсягів даних через серверні механізми.

### **Що було зроблено:**

* **Новий ендпоїнт**: Додано метод `GET /api/taxes/orders` у роутері `taxes.py`.
* **Серверна пагінація**: Реалізовано параметри `limit` та `offset` для вибірки даних частинами прямо на рівні SQL-запиту.
* **Метадані у відповіді**: Сервер повертає об'єкт `OrdersListResponse`, який містить масив замовлень та поле `total_count` (загальна кількість записів у БД), що необхідно для коректної побудови навігації сторінок на фронтенді.
* **Фільтрація за датами**: Додано можливість пошуку замовлень у діапазоні `start_date` та `end_date` (фільтрація по полю `timestamp`).
* **Динамічне сортування**: Реалізовано сортування результатів за полями `timestamp`, `subtotal`, `tax_amount` або `total_amount` у порядку `asc` чи `desc`.

### **Технічні деталі:**

* **Схеми**: Додано схему `OrdersListResponse` у файл `order.py` для валідації пагінованих відповідей.
* **Безпека**: Для параметрів сортування використано регулярні вирази (Regex), щоб запобігти помилкам та потенційним SQL-ін'єкціям.
* **Оптимізація**: Розрахунок `total_count` виконується до застосування зсувів пагінації, що гарантує точність метаданих.

### **Як протестувати:**

1. Запустити сервер: `uvicorn app.main:app --reload`.
2. Перейти до Swagger UI (`/docs`).
3. Виконати запит `GET /api/taxes/orders` із різними параметрами `limit`, `offset` та `sort_by`.
4. Перевірити, що відповідь містить `total_count` та масив замовлень.

---

